### PR TITLE
Feature/trigger changelog if pr

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -34,6 +34,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   update-changelog:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     outputs:
       was_updated: ${{ steps.check-change.outputs.change_detected }}
@@ -109,6 +110,7 @@ jobs:
           fi
 
   check_changelog:
+    if: github.event_name == 'pull_request'
     needs: update-changelog
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ All notable changes to the sample iframe app will be documented in this file.
 
 ## 1.2.1
 
-- Small update in changelog action, it will check and update changelog when its a PR, Currently some builds show that they are failing because of the changelog, the changelog logic shouldn't run unless if its a pull request.
 - Bugfix: Schema file was not included, preventing installation as a component
 - Bugfix: Manifest build content template was never resolved, so it has been removed.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to the sample iframe app will be documented in this file.
 
 ## 1.2.1
+
+- Small update in changelog action, it will check and update changelog when its a PR, Currently some builds show that they are failing because of the changelog, the changelog logic shouldn't run unless if its a pull request.
 - Bugfix: Schema file was not included, preventing installation as a component
 - Bugfix: Manifest build content template was never resolved, so it has been removed.
 


### PR DESCRIPTION
Small update in changelog action, it will check and update changelog when its a PR, Currently some builds show that they are failing because of the changelog, the changelog logic shouldn't run unless if its a pull request.