### PR TITLE
add build info section in manifest (port changes from PR #46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the sample iframe app will be documented in this file.
 
+## 2.8.1
+
+- Bugfix: Generate build information in manifest.
+
+
+## 2.8.0
+
+- Enhancement: The app now contains examples of differences between standalone mode and simple standalone mode
+
+
 ## 1.2.1
 
 - Bugfix: Schema file was not included, preventing installation as a component
@@ -12,6 +22,4 @@ All notable changes to the sample iframe app will be documented in this file.
 
 - Enhancement: The app now contains a manifest file so that it can be installed with `zwe components install`
 
-## 2.8.0
 
-- Enhancement: The app now contains examples of differences between standalone mode and simple standalone mode

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -18,6 +18,11 @@ license: EPL-2.0
 repository:
   type: git
   url: https://github.com/zowe/sample-iframe-app.git
+build:
+  branch: "{{build.branch}}"
+  number: "{{build.number}}"
+  commitHash: "{{build.commitHash}}"
+  timestamp: {{build.timestamp}}
 # we do not specify encoding here because its already tagged ascii
 appfwPlugins:
   - path: .


### PR DESCRIPTION
Port changes from PR #46 for v2.x/staging

The fix enables the zowe-actions/zlux-builds/plugins/prepare-workflow to generate build information in the manifest.yaml.